### PR TITLE
fix: add rancher annotations

### DIFF
--- a/charts/unique-ingress-policy/Chart.yaml
+++ b/charts/unique-ingress-policy/Chart.yaml
@@ -1,4 +1,7 @@
 annotations:
+  catalog.cattle.io/hidden: "true"
+  catalog.cattle.io/type: kubewarden-policy
+  catalog.cattle.io/ui-component: kubewarden
   kubewarden/contextAwareResources: |
     - apiVersion: networking.k8s.io/v1
       kind: Ingress

--- a/charts/verify-image-signatures/Chart.yaml
+++ b/charts/verify-image-signatures/Chart.yaml
@@ -1,4 +1,7 @@
 annotations:
+  catalog.cattle.io/hidden: "true"
+  catalog.cattle.io/type: kubewarden-policy
+  catalog.cattle.io/ui-component: kubewarden
   kubewarden/displayName: Verify Image Signatures
   kubewarden/mutation: "true"
   kubewarden/registry: ghcr.io

--- a/pkg2chart/main.go
+++ b/pkg2chart/main.go
@@ -75,6 +75,11 @@ func main() {
 	annotations["kubewarden/repository"] = ref.Context().RepositoryStr()
 	annotations["kubewarden/tag"] = ref.TagStr()
 
+	// Add annotations required by Rancher
+	annotations["catalog.cattle.io/ui-component"] = "kubewarden"
+	annotations["catalog.cattle.io/hidden"] = "true"
+	annotations["catalog.cattle.io/type"] = "kubewarden-policy"
+
 	annotations["kubewarden/displayName"] = pkg.DisplayName
 
 	metadata := chart.Metadata{


### PR DESCRIPTION
## Description

In order to have the Policy Helm charts displayed correctly within the UI, we need to have a few annotations added to each policy:

```
catalog.cattle.io/ui-component: kubewarden
catalog.cattle.io/hidden: 'true'
catalog.cattle.io/type: kubewarden-policy
```
