### PR TITLE
ci: add release policy workflow

### DIFF
--- a/.github/workflows/release_policy.yml
+++ b/.github/workflows/release_policy.yml
@@ -1,0 +1,104 @@
+name: Release Policy
+
+on:
+  workflow_dispatch:
+    inputs:
+      owner:
+        description: "Owner"
+        required: true
+        type: string
+      repo:
+        description: "Repository"
+        required: true
+        type: string
+      tag:
+        description: "Tag to release"
+        required: true
+        type: string
+  repository_dispatch:
+    types: [release-policy]
+
+jobs:
+  release-policy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Extract repository info
+        id: repo-info
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "owner=${{ github.event.inputs.owner }}" >> $GITHUB_OUTPUT
+            echo "repo=${{ github.event.inputs.repo }}" >> $GITHUB_OUTPUT
+            echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "owner=${{ github.event.client_payload.owner }}" >> $GITHUB_OUTPUT
+            echo "repo=${{ github.event.client_payload.repo }}" >> $GITHUB_OUTPUT
+            echo "tag=${{ github.event.client_payload.tag }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Clone source repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ steps.repo-info.outputs.owner }}/${{ steps.repo-info.outputs.repo }}
+          ref: ${{ steps.repo-info.outputs.tag }}
+          path: policy-source
+
+      - name: Setup Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version: "1.24"
+
+      - name: Create directory structure
+        run: |
+          TARGET_DIR="charts/${{ steps.repo-info.outputs.repo }}"
+          mkdir -p "$TARGET_DIR"
+
+          if [ ! -f "policy-source/README.md" ]; then
+            echo "::error::README.md file not found in the source repository"
+            exit 1
+          fi
+
+          if [ ! -f "policy-source/LICENSE" ]; then
+            echo "::error::LICENSE file not found in the source repository"
+            exit 1
+          fi
+
+          cp "policy-source/README.md" "$TARGET_DIR/"
+          cp "policy-source/LICENSE" "$TARGET_DIR/"
+
+          if [ -f "policy-source/questions-ui.yml" ]; then
+            cp "policy-source/questions-ui.yml" "$TARGET_DIR/questions.yaml"
+          else
+            echo "::notice::questions-ui.yml file not found in the source repository"
+          fi
+
+      - name: Generate Chart.yaml
+        run: |
+          TARGET_DIR="charts/${{ steps.repo-info.outputs.repo }}"
+
+          cd pkg2chart
+
+          go run main.go \
+            --pkg ../policy-source/artifacthub-pkg.yml \
+            --repo ../policy-source/artifacthub-repo.yml \
+            --output ../$TARGET_DIR/Chart.yaml
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "chore: update policy ${{ steps.repo-info.outputs.repo }} to ${{ steps.repo-info.outputs.tag }}"
+          body: |
+            Updates policy to ${{ steps.repo-info.outputs.repo }} ${{ steps.repo-info.outputs.tag }}
+          commit-message: "chore: update policy ${{ steps.repo-info.outputs.repo }} to ${{ steps.repo-info.outputs.tag }}"
+          add-paths: |
+            charts
+          branch: update-policy-${{ steps.repo-info.outputs.repo }}-${{ steps.repo-info.outputs.tag }}
+          base: main
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,52 @@
-# Kubewarden policy-charts
+# Kubewarden policy-catalog
 
-[![Incubating](https://img.shields.io/badge/status-incubating-orange?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#incubating)
+This repository contains the catalog of Kubewarden policies to be consumed by the Rancher UI. The catalog is published to GitHub Pages at [https://kubewarden.github.io/policy-catalog/](https://kubewarden.github.io/policy-catalog/).
 
-This repository contains Kubewarden policies packaged as Helm charts for Rancher UI.
+## Release Policy Workflow
+
+This repository includes a GitHub Action workflow for automatically updating policy references when new versions are released.
+
+### Triggering the Workflow
+
+The workflow can be triggered in two ways:
+
+1. **Manually via workflow dispatch** - requires the following inputs:
+
+   - `owner`: Repository owner
+   - `repo`: Repository name
+   - `tag`: Tag to release
+
+2. **Automatically via repository dispatch** - requires this payload:
+   ```json
+   {
+     "event_type": "release-policy",
+     "client_payload": {
+       "owner": "org-name",
+       "repo": "repo-name",
+       "tag": "v1.0.0"
+     }
+   }
+   ```
+
+### What the Workflow Does
+
+The workflow performs these steps:
+
+- Fetches the policy repository at the specified tag
+- Creates a directory structure under `charts/<repo-name>/`
+- Copies required files (README.md, LICENSE)
+- Copies optional files (questions-ui.yml → questions.yaml)
+- Generates Chart.yaml using the pkg2chart tool
+- Creates a PR with the changes
+
+### Required Files
+
+Each policy repository must contain the following:
+
+- README.md
+- LICENSE
+- artifacthub-pkg.yml and artifacthub-repo.yml (for Chart.yaml generation)
+
+Optional:
+
+- questions-ui.yml (will be renamed to questions.yaml)


### PR DESCRIPTION
## Description
Adds the release policy workflow.

This workflow can be triggered in two ways:
1. **Manually via workflow dispatch** - requires the following inputs:
   - `owner`: Repository owner
   - `repo`: Repository name
   - `tag`: Tag to release

2. **Automatically via repository dispatch** - requires this payload:
   ```json
   {
     "event_type": "release-policy",
     "client_payload": {
       "owner": "org-name",
       "repo": "repo-name",
       "tag": "v1.0.0",
     }
   }
   ```

The workflow performs these steps:
- Fetches the policy repository at the specified tag
- Creates a directory structure under `charts/<repo-name>/`
- Copies required files (README.md, LICENSE)
- Copies optional files (questions-ui.yml → questions.yaml)
- Generates Chart.yaml using the pkg2chart tool
- Creates a signed-off PR with the changes
