### PR TITLE
ci(release-policy): add artifacthub-pkg.yml path input

### DIFF
--- a/.github/workflows/release_policy.yml
+++ b/.github/workflows/release_policy.yml
@@ -15,6 +15,11 @@ on:
         description: "Tag to release"
         required: true
         type: string
+      artifacthub_pkg_path:
+        description: "Path to the Artifact Hub package file"
+        required: true
+        default: "artifacthub-pkg.yml"
+        type: string
   repository_dispatch:
     types: [release-policy]
 
@@ -36,10 +41,17 @@ jobs:
             echo "owner=${{ github.event.inputs.owner }}" >> $GITHUB_OUTPUT
             echo "repo=${{ github.event.inputs.repo }}" >> $GITHUB_OUTPUT
             echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+            echo "artifacthub_pkg_path=${{ github.event.inputs.artifacthub_pkg_path }}" >> $GITHUB_OUTPUT
           else
             echo "owner=${{ github.event.client_payload.owner }}" >> $GITHUB_OUTPUT
             echo "repo=${{ github.event.client_payload.repo }}" >> $GITHUB_OUTPUT
             echo "tag=${{ github.event.client_payload.tag }}" >> $GITHUB_OUTPUT
+
+            if [[ -n "${{ github.event.client_payload.artifacthub_pkg_path }}" ]]; then
+              echo "artifacthub_pkg_path=${{ github.event.client_payload.artifacthub_pkg_path }}" >> $GITHUB_OUTPUT
+            else
+              echo "artifacthub_pkg_path=artifacthub-pkg.yml" >> $GITHUB_OUTPUT
+            fi
           fi
 
       - name: Clone source repository
@@ -81,13 +93,14 @@ jobs:
       - name: Generate Chart.yaml
         run: |
           TARGET_DIR="charts/${{ steps.repo-info.outputs.repo }}"
+          ARTIFACTHUB_PKG_PATH="${{ steps.repo-info.outputs.artifacthub_pkg_path }}"
 
           cd pkg2chart
 
           go run main.go \
-            --pkg ../policy-source/artifacthub-pkg.yml \
-            --repo ../policy-source/artifacthub-repo.yml \
-            --output ../$TARGET_DIR/Chart.yaml
+            --pkg "../policy-source/$ARTIFACTHUB_PKG_PATH" \
+            --repo "../policy-source/artifacthub-repo.yml" \
+            --output "../$TARGET_DIR/Chart.yaml"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
@@ -95,7 +108,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "chore: update policy ${{ steps.repo-info.outputs.repo }} to ${{ steps.repo-info.outputs.tag }}"
           body: |
-            Updates policy to ${{ steps.repo-info.outputs.repo }} ${{ steps.repo-info.outputs.tag }}
+            Updates policy ${{ steps.repo-info.outputs.repo }} to ${{ steps.repo-info.outputs.tag }}
           commit-message: "chore: update policy ${{ steps.repo-info.outputs.repo }} to ${{ steps.repo-info.outputs.tag }}"
           add-paths: |
             charts

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The workflow can be triggered in two ways:
      "client_payload": {
        "owner": "org-name",
        "repo": "repo-name",
-       "tag": "v1.0.0"
+       "tag": "v1.0.0",
+       "artifacthub-pkg": "path/to/artifacthub-pkg.yml" # Optional, defaults to `./artifacthub-pkg.yml`
      }
    }
    ```


### PR DESCRIPTION
## Description  

Adds an optional `artifacthub-pkg.yml` path input to the workflow dispatch.  

This is necessary because monorepos contain multiple `artifacthub-pkg.yml` filesrather than a single file at the root. Instead, these files are in the policy directories, such as `policies/<policy name>`.

The input defaults to `./artifacthub-pkg.yml` for both `workflow_dispatch` and `repository_dispatch`

