### PR TITLE
ci: add concurrency group to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: "release"
+  cancel-in-progress: false
+
 jobs:
   release:
     permissions:


### PR DESCRIPTION
## Description

Limits the concurrency of the release workflow to 1, to prevent failures when two releases are triggered at the same time.