### PR TITLE
ci(release-policy): add optional chart_dir parameter 

### DIFF
--- a/.github/workflows/release_policy.yml
+++ b/.github/workflows/release_policy.yml
@@ -20,6 +20,10 @@ on:
         required: true
         default: "artifacthub-pkg.yml"
         type: string
+      chart_dir:
+        description: "Override the chart directory name (defaults to repo name if not provided)"
+        required: false
+        type: string
   repository_dispatch:
     types: [release-policy]
 
@@ -42,6 +46,12 @@ jobs:
             echo "repo=${{ github.event.inputs.repo }}" >> $GITHUB_OUTPUT
             echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
             echo "artifacthub_pkg_path=${{ github.event.inputs.artifacthub_pkg_path }}" >> $GITHUB_OUTPUT
+            
+            if [[ -n "${{ github.event.inputs.chart_dir }}" ]]; then
+              echo "chart_dir=${{ github.event.inputs.chart_dir }}" >> $GITHUB_OUTPUT
+            else
+              echo "chart_dir=${{ github.event.inputs.repo }}" >> $GITHUB_OUTPUT
+            fi
           else
             echo "owner=${{ github.event.client_payload.owner }}" >> $GITHUB_OUTPUT
             echo "repo=${{ github.event.client_payload.repo }}" >> $GITHUB_OUTPUT
@@ -51,6 +61,12 @@ jobs:
               echo "artifacthub_pkg_path=${{ github.event.client_payload.artifacthub_pkg_path }}" >> $GITHUB_OUTPUT
             else
               echo "artifacthub_pkg_path=artifacthub-pkg.yml" >> $GITHUB_OUTPUT
+            fi
+            
+            if [[ -n "${{ github.event.client_payload.chart_dir }}" ]]; then
+              echo "chart_dir=${{ github.event.client_payload.chart_dir }}" >> $GITHUB_OUTPUT
+            else
+              echo "chart_dir=${{ github.event.client_payload.repo }}" >> $GITHUB_OUTPUT
             fi
           fi
 
@@ -68,7 +84,7 @@ jobs:
 
       - name: Create directory structure
         run: |
-          TARGET_DIR="charts/${{ steps.repo-info.outputs.repo }}"
+          TARGET_DIR="charts/${{ steps.repo-info.outputs.chart_dir }}"
           mkdir -p "$TARGET_DIR"
 
           if [ ! -f "policy-source/README.md" ]; then
@@ -92,7 +108,7 @@ jobs:
 
       - name: Generate Chart.yaml
         run: |
-          TARGET_DIR="charts/${{ steps.repo-info.outputs.repo }}"
+          TARGET_DIR="charts/${{ steps.repo-info.outputs.chart_dir }}"
           ARTIFACTHUB_PKG_PATH="${{ steps.repo-info.outputs.artifacthub_pkg_path }}"
 
           cd pkg2chart

--- a/README.md
+++ b/README.md
@@ -17,15 +17,16 @@ The workflow can be triggered in two ways:
    - `tag`: Tag to release
 
 2. **Automatically via repository dispatch** - requires this payload:
-   ```json
+   ```jsonc
    {
      "event_type": "release-policy",
      "client_payload": {
        "owner": "org-name",
        "repo": "repo-name",
        "tag": "v1.0.0",
-       "artifacthub-pkg": "path/to/artifacthub-pkg.yml" # Optional, defaults to `./artifacthub-pkg.yml`
-     }
+       "artifacthub-pkg": "path/to/artifacthub-pkg.yml", // Optional, defaults to `./artifacthub-pkg.yml`
+       "chart_dir": "MyPolicy", // Optional, defaults to repo name
+     },
    }
    ```
 


### PR DESCRIPTION
## Description

This change allows users to specify a custom chart folder name that's different 
from the repository name, making the workflow more flexible for cases where the 
chart naming convention differs from the repository naming, e.g. monorepos.

