### PR TITLE
refactor: Substitute peter-evans/create-pull-request with gh cli

### DIFF
--- a/.github/workflows/release_policy.yml
+++ b/.github/workflows/release_policy.yml
@@ -138,15 +138,24 @@ jobs:
             --output "../$TARGET_DIR/Chart.yaml"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: "chore: update policy ${{ steps.repo-info.outputs.repo }} to ${{ steps.repo-info.outputs.tag }}"
-          body: |
-            Updates policy ${{ steps.repo-info.outputs.repo }} to ${{ steps.repo-info.outputs.tag }}
-          commit-message: "chore: update policy ${{ steps.repo-info.outputs.repo }} to ${{ steps.repo-info.outputs.tag }}"
-          add-paths: |
-            charts
-          branch: update-policy-${{ steps.repo-info.outputs.repo }}-${{ steps.repo-info.outputs.tag }}
-          base: main
-          delete-branch: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="chore: update policy ${{ steps.repo-info.outputs.repo }} to ${{ steps.repo-info.outputs.tag }}"
+          BODY="Updates policy ${{ steps.repo-info.outputs.repo }} to ${{ steps.repo-info.outputs.tag }}"
+          COMMIT_MSG="chore: update policy ${{ steps.repo-info.outputs.repo }} to ${{ steps.repo-info.outputs.tag }}"
+
+          TARGET_DIR="charts"
+          BRANCH_NAME="update-policy-${{ steps.repo-info.outputs.repo }}-${{ steps.repo-info.outputs.tag }}"
+
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git checkout -b "$BRANCH_NAME"
+          git add "$TARGET_DIR"
+          git commit -m "$COMMIT_MSG"
+          git push origin "$BRANCH_NAME"
+          gh pr create \
+            --title "$TITLE" \
+            --body "$BODY" \
+            --base main \
+            --head "$BRANCH_NAME"


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/kubewarden-controller/issues/1100

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
Not replicating the `delete-branch` functionality of `peter-evans/create-pull-request`, that, upon next run and before creating the PR, would delete the branch to make sure the branch was pristine. This is because we now have the `policy-catalog` repo configured as instructed by `peter-evans/create-pull-request` with "Automatically delete head branches feature" in the repository settings.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Run:
https://github.com/viccuad/policy-catalog/actions/runs/14835540585/job/41645863267
Which opened:
https://github.com/viccuad/policy-catalog/pull/1

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
